### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm run e2e-test
 example:
 
 ```js
-import ADB from 'appium-adb';
+import { ADB } from 'appium-adb';
 
 const adb = await ADB.createADB();
 console.log(await adb.getPIDsByName('com.android.phone'));


### PR DESCRIPTION
fix https://github.com/appium/appium-adb/issues/649 (`ADB.createADB is not a function` when doing `import ADB from 'appium-adb'` as per readme.md)